### PR TITLE
Fix timezone double addition after applying sunrise/sunset offsets

### DIFF
--- a/esp8266_sunlight_switch.ino
+++ b/esp8266_sunlight_switch.ino
@@ -141,10 +141,16 @@ time_t getSunEventUTC(time_t now, bool isSunrise, float lat, float lon) {
 
 void updateSunTimes() {
   time_t now = timeClient.getEpochTime();
-  sunriseRaw = getSunEventUTC(now, true, latitude, longitude) + utcOffset;
-  sunsetRaw  = getSunEventUTC(now, false, latitude, longitude) + utcOffset;
-  sunriseFinal = sunriseRaw + sunriseOffsetMin * 60;
-  sunsetFinal  = sunsetRaw  + sunsetOffsetMin * 60;
+
+  // Calculate sunrise and sunset in UTC first
+  time_t sunriseUTC = getSunEventUTC(now, true, latitude, longitude);
+  time_t sunsetUTC  = getSunEventUTC(now, false, latitude, longitude);
+
+  // Convert to local time and apply user offsets
+  sunriseRaw = sunriseUTC + utcOffset;
+  sunsetRaw  = sunsetUTC + utcOffset;
+  sunriseFinal = sunriseUTC + sunriseOffsetMin * 60 + utcOffset;
+  sunsetFinal  = sunsetUTC  + sunsetOffsetMin * 60 + utcOffset;
 }
 
 String formatTime(time_t t) {


### PR DESCRIPTION
## Summary
- prevent timezone from being reapplied after sunrise/sunset offsets by calculating event times in UTC first

## Testing
- `arduino-cli compile --fqbn esp8266:esp8266:generic esp8266_sunlight_switch.ino` *(fails: command not found)*
- `platformio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ae74898388331836a07d3ea6eb91f